### PR TITLE
gRPC reverse proxy 

### DIFF
--- a/inventory/classes/freeplane/init.yml
+++ b/inventory/classes/freeplane/init.yml
@@ -3,6 +3,6 @@ parameters:
   freeplane_version: 1.10.6u1
   freeplane_root: ${kapitan_root}/freeplane-${freeplane_version}
   freeplane_config: ${freeplane_root}/1.10.x/
-  freeplane_plugin_grpc_version: 0.0.1
+  freeplane_plugin_grpc_version: 0.0.2
 
 

--- a/inventory/classes/freeplane_plugin_grpc/init.yml
+++ b/inventory/classes/freeplane_plugin_grpc/init.yml
@@ -1,0 +1,6 @@
+---
+parameters:
+  # grpc discovery ?
+  freeplane_grpc_listen4:
+    addr: "0.0.0.0"
+    port: "50053"

--- a/inventory/classes/jsonnet/k8s-libsonnet.yml
+++ b/inventory/classes/jsonnet/k8s-libsonnet.yml
@@ -1,0 +1,8 @@
+---
+parameters:
+  kapitan:
+    dependencies:
+      - source: https://github.com/jsonnet-libs/k8s-libsonnet
+        ref: 85543e49238903ac14b486321bd3d60fef09d9ef
+        type: git
+        output_path: files/github.com/jsonnet-libs/k8s-libsonnet

--- a/inventory/classes/kubernetes/freeplane-grpc-reverse-proxy.yml
+++ b/inventory/classes/kubernetes/freeplane-grpc-reverse-proxy.yml
@@ -1,0 +1,27 @@
+---
+classes:
+  - kubernetes.reverse-grpc-svc
+  - freeplane_plugin_grpc
+
+parameters:
+  kubernetes:
+    reverse-grpc-proxy4:
+      freeplane-grpc-proxy:
+        name: freeplane reverse proxy
+        namespace: mindwm
+        container_port: ${gproxy4_container_port}
+        env:
+          - name: MINIKUBE_IP
+            valueFrom:
+              fieldRef:
+                fieldPath: status.hostIP
+          - name: DST_PORT
+            value: ${freeplane_grpc_listen4:port}
+        svc:
+          name: freeplane-grpc-reverse-proxy4
+          port: ${gproxy4_container_port}
+        proxy_to:
+          shell: |
+            export DST_ADDR=`echo $MINIKUBE_IP | awk -F. '{$4=""; print $1"."$2"."$3".1"}'`
+
+

--- a/inventory/classes/kubernetes/reverse-grpc-svc.yml
+++ b/inventory/classes/kubernetes/reverse-grpc-svc.yml
@@ -1,0 +1,33 @@
+---
+classes:
+  - jsonnet.k8s-libsonnet
+parameters:
+  gproxy4_container_port: 80
+  gproxy4_container_image: nginx:latest
+  gproxy4_container_entrypoint: |
+    cat<<EOF > /etc/nginx/conf.d/default.conf
+      upstream grpc_backend {
+        server $DST_ADDR:$DST_PORT;
+      }
+
+      server {
+        listen 80 http2;
+
+        location / {
+          grpc_pass grpc://grpc_backend;
+          error_log /dev/stderr;
+          access_log /dev/stdout;
+        }
+      }
+    EOF
+    exec nginx -g 'daemon off;'
+
+  kapitan:
+    compile:
+      - input_type: jsonnet
+        input_paths:
+          - jsonnet/reverse-proxy-grpc4.jsonnet
+          - jsonnet/reverse-proxy-svc.jsonnet
+        output_path: reverse-proxy-grpc4
+        output_type: yaml
+

--- a/inventory/targets/freeplane.yml
+++ b/inventory/targets/freeplane.yml
@@ -11,6 +11,7 @@ classes:
   - freeplane.lib.fp
   - freeplane.scripts.kapitan-node
   - freeplane.src
+  - freeplane_plugin_grpc
 
 parameters:
   target_name: freeplane
@@ -20,6 +21,8 @@ parameters:
       freeplane_start: |
         cd ${freeplane_root}
         sed -i 's,^userfpdir=.*,userfpdir="${freeplane_root}",' ./freeplane.sh
+        export GRPC_LISTEN_ADDR=${freeplane_grpc_listen4:addr}
+        export GRPC_LISTEN_PORT=${freeplane_grpc_listen4:port}
         bash ./freeplane.sh
 
 

--- a/inventory/targets/kafka-consumers/kafka-textfsm-to-freeplane.yml
+++ b/inventory/targets/kafka-consumers/kafka-textfsm-to-freeplane.yml
@@ -7,9 +7,9 @@ classes:
   - kapitan.bash.compile-fetch
   - tmuxinator.kapitan
   - kafka.k8s-consumer
-
   - freeplane.grpc
   - grpc.protoc
+  - kubernetes.freeplane-grpc-reverse-proxy
 
 parameters:
   target_name: kafka-textfsm-to-freeplane
@@ -18,14 +18,17 @@ parameters:
     consumers:
       textfsm-to-freeplane:
         topic: mindwm-objects
+        env:
+          FREEPLANE_GRPC4_ENDPOINT: "${kubernetes:reverse-grpc-proxy4:freeplane-grpc-proxy:svc:name}.${kubernetes:reverse-grpc-proxy4:freeplane-grpc-proxy:namespace}:${kubernetes:reverse-grpc-proxy4:freeplane-grpc-proxy:svc:port}"
         python:
           init: |
             import grpc
             import freeplane_pb2
             import freeplane_pb2_grpc
+            import os
             # 192.168.49.1
             pprint.pprint("init")
-            channel = grpc.insecure_channel('192.168.49.1:50051')
+            channel = grpc.insecure_channel(os.environ.get('FREEPLANE_GRPC4_ENDPOINT', 'freeplane-grpc-proxy4:80'))
             fp = freeplane_pb2_grpc.FreeplaneStub(channel)
             fp.CreateChild(freeplane_pb2.CreateChildRequest(name='hello-from-kubernetes', parent_node_id = ""))
           consumer: |

--- a/inventory/targets/kubernetes/reverse-grpc-freeplane-proxy.yml
+++ b/inventory/targets/kubernetes/reverse-grpc-freeplane-proxy.yml
@@ -1,0 +1,12 @@
+---
+classes:
+  - common
+  - vim
+  - bash.kapitan
+  - tmuxinator
+  - tmuxinator.kapitan
+  - kubernetes.freeplane-grpc-reverse-proxy
+
+parameters:
+  target_name: reverse-grpc-freeplane-proxy
+

--- a/lib/jsonnet/kafka-k8s-consumer/deployment.jsonnet
+++ b/lib/jsonnet/kafka-k8s-consumer/deployment.jsonnet
@@ -13,7 +13,7 @@ local k8s_deployment(name, consumer_spec) =
     k8s.core.v1.container.new(name="consumer", image=p.consumer_image.repo_prefix + name) +
         k8s.core.v1.container.withEnvMap({
             'KAFKA_BOOTSTRAP_SERVER': p.kafka_cluster_name + "-kafka-external-bootstrap." + p.kafka_k8s_namespace + ":" + p.kafka_port
-        }) + k8s.core.v1.container.withImagePullPolicy("Never")
+        } + (if std.objectHas(consumer_spec, 'env') then consumer_spec.env else {}) ) + k8s.core.v1.container.withImagePullPolicy("Never")
   ]);
   deployment + k8s.apps.v1.deployment.metadata.withNamespace(p.kafka.k8s.consumer_namespace);
 

--- a/lib/jsonnet/reverse-proxy-grpc4.jsonnet
+++ b/lib/jsonnet/reverse-proxy-grpc4.jsonnet
@@ -1,0 +1,24 @@
+local kap = import "lib/kapitan.libjsonnet";
+local inventory = kap.inventory();
+local p = inventory.parameters;
+
+local k8s = import "files/github.com/jsonnet-libs/k8s-libsonnet/1.23/main.libsonnet";
+
+local k8s_reverse_grpc_proxy4_deployment(name, gproxy4_spec) =
+  local deployment = k8s.apps.v1.deployment.new(name=name, containers=[
+    k8s.core.v1.container.new(name="reverse-grpc-proxy4", image=p.gproxy4_container_image) +
+        //k8s.core.v1.container.withImagePullPolicy("Never") +
+	k8s.core.v1.container.withCommand(["/bin/sh"]) +
+	k8s.core.v1.container.withArgs(["-c",
+		gproxy4_spec.proxy_to.shell + "\n" +
+ 		p.gproxy4_container_entrypoint]
+	) +
+	{ env: gproxy4_spec.env } +
+	{ ports: [ { containerPort: p.gproxy4_container_port } ] }
+
+  ]);
+  deployment + k8s.apps.v1.deployment.metadata.withNamespace(gproxy4_spec.namespace);
+
+{
+	[gproxy4]: k8s_reverse_grpc_proxy4_deployment(gproxy4, p.kubernetes["reverse-grpc-proxy4"][gproxy4]) for gproxy4 in std.objectFieldsAll(p.kubernetes["reverse-grpc-proxy4"])
+}

--- a/lib/jsonnet/reverse-proxy-svc.jsonnet
+++ b/lib/jsonnet/reverse-proxy-svc.jsonnet
@@ -1,0 +1,18 @@
+local kap = import "lib/kapitan.libjsonnet";
+local inventory = kap.inventory();
+local p = inventory.parameters;
+
+local k8s = import "files/github.com/jsonnet-libs/k8s-libsonnet/1.23/main.libsonnet";
+
+local generate_service(name, namespace, selector) =
+  k8s.core.v1.service.new(
+    name=name,
+    selector={
+      "name": selector,
+    },
+    ports=[{"port": p.gproxy4_container_port, "targetPort": p.gproxy4_container_port}]
+  ) + k8s.core.v1.service.metadata.withNamespace(namespace);
+
+{
+	[gproxy4 + "-svc"]: generate_service(p.kubernetes["reverse-grpc-proxy4"][gproxy4].svc.name, p.kubernetes["reverse-grpc-proxy4"][gproxy4].namespace, gproxy4) for gproxy4 in std.objectFieldsAll(p.kubernetes["reverse-grpc-proxy4"])
+}


### PR DESCRIPTION
Added gRPC reverse proxy to enable interaction between code(kafka consumers) deployed inside Kubernetes and the host-running Freeplane instance.