### PR TITLE
Rabbitmq

### DIFF
--- a/inventory/classes/rabbitmq/common.yml
+++ b/inventory/classes/rabbitmq/common.yml
@@ -1,0 +1,3 @@
+---
+parameters:
+  rabbitmq_version: 3.12.4

--- a/inventory/classes/rabbitmq/common.yml
+++ b/inventory/classes/rabbitmq/common.yml
@@ -1,3 +1,5 @@
 ---
 parameters:
   rabbitmq_version: 3.12.4
+  rabbitmq_user: user
+  rabbitmq_password: password

--- a/inventory/classes/rabbitmq/helm.yml
+++ b/inventory/classes/rabbitmq/helm.yml
@@ -1,0 +1,22 @@
+---
+classes:
+  - helm
+  - rabbitmq.common
+parameters:
+  rabbitmq_chart_version: 12.1.4
+  rabbitmq_release_name: rabbitmq
+  rabbitmq_helm_chart_path: files/helm-charts/rabbitmq
+
+  bash:
+    functions:
+      rabbitmq_helm_install: |
+        helm upgrade --install --namespace ${rabbitmq_namespace} ${rabbitmq_release_name} ${kapitan_root}/${rabbitmq_helm_chart_path} -f ${compiled_dir}/helm/values.yaml
+      rabbitmq_helm_delete: |
+        helm delete --namespace ${rabbitmq_namespace} ${rabbitmq_release_name}
+  kapitan:
+    dependencies:
+      - output_path: ${rabbitmq_helm_chart_path}
+        type: helm
+        source: https://charts.bitnami.com/bitnami
+        version: ${rabbitmq_chart_version}
+        chart_name: rabbitmq

--- a/inventory/classes/rabbitmq/k8s.yml
+++ b/inventory/classes/rabbitmq/k8s.yml
@@ -1,0 +1,10 @@
+---
+classes:
+  - rabbitmq.common
+  - rabbitmq.helm
+parameters:
+  rabbitmq_namespace: rabbitmq
+  rabbitmq_image:
+    repo: bitnami/rabbitmq
+    tag: ${rabbitmq_version}-debian-11-r0
+

--- a/inventory/classes/rabbitmq/k8s.yml
+++ b/inventory/classes/rabbitmq/k8s.yml
@@ -3,9 +3,19 @@ classes:
   - rabbitmq.common
   - rabbitmq.helm
 parameters:
+  rabbitmq_exchanges:
+    io-context:
+      type: fanout
+
   rabbitmq_namespace: rabbitmq
   rabbitmq_manage_node_port: 32100
   rabbitmq_image:
     repo: bitnami/rabbitmq
     tag: ${rabbitmq_version}-debian-11-r0
 
+  kapitan:
+    compile:
+      - input_paths:
+          - templates/rabbitmq
+        output_path: rabbitmq
+        input_type: jinja2

--- a/inventory/classes/rabbitmq/k8s.yml
+++ b/inventory/classes/rabbitmq/k8s.yml
@@ -4,6 +4,7 @@ classes:
   - rabbitmq.helm
 parameters:
   rabbitmq_namespace: rabbitmq
+  rabbitmq_manage_node_port: 32100
   rabbitmq_image:
     repo: bitnami/rabbitmq
     tag: ${rabbitmq_version}-debian-11-r0

--- a/inventory/targets/rabbitmq.yml
+++ b/inventory/targets/rabbitmq.yml
@@ -16,5 +16,10 @@ parameters:
         repository: ${rabbitmq_image:repo}
         tag: ${rabbitmq_image:tag}
       auth:
-        username: rabbitmq
-        password: rabbitmq-password
+        username: ${rabbitmq_user}
+        password: ${rabbitmq_password}
+        securePassword: false
+      service:
+        type: NodePort
+        nodePorts:
+          manager: "${rabbitmq_manage_node_port}"

--- a/inventory/targets/rabbitmq.yml
+++ b/inventory/targets/rabbitmq.yml
@@ -1,0 +1,20 @@
+---
+classes:
+  - common
+  - vim
+  - tmuxinator
+  - bash.kapitan
+  - tmuxinator.kapitan
+  - kapitan.bash.compile-fetch
+  - rabbitmq.k8s
+
+parameters:
+  target_name: rabbitmq
+  helm:
+    values:
+      image:
+        repository: ${rabbitmq_image:repo}
+        tag: ${rabbitmq_image:tag}
+      auth:
+        username: rabbitmq
+        password: rabbitmq-password

--- a/inventory/targets/rabbitmq.yml
+++ b/inventory/targets/rabbitmq.yml
@@ -19,6 +19,7 @@ parameters:
         username: ${rabbitmq_user}
         password: ${rabbitmq_password}
         securePassword: false
+      # temporarily way to create fanout exchange
       service:
         type: NodePort
         nodePorts:

--- a/inventory/targets/vector.yml
+++ b/inventory/targets/vector.yml
@@ -11,6 +11,8 @@ classes:
   - kapitan.bash.compile-fetch
   - kafka
   - vector
+  - rabbitmq.common
+  - rabbitmq.k8s
   - vector.tmux-bytestream-kafka
 #  - vector.tmux-kafka
 #  - vector.console-output
@@ -316,6 +318,18 @@ parameters:
             compression: "none"
             encoding:
               codec: json
+
+          rabbitmq-tmux-pane-raw-io-context:
+            type: amqp
+            inputs:
+              - tmux-pane-raw-io-context
+            #connection: "amqp://${rabbitmq_user}:${rabbitmq_password}@${rabbitmq_release_name}.${rabbitmq_namespace}:5672/%2f?timeout=10"
+            connection:
+              connection_string: "amqp://${rabbitmq_user}:${rabbitmq_password}@${rabbitmq_release_name}.${rabbitmq_namespace}:5672/%2f?timeout=10"
+            exchange: io-context
+            encoding:
+              codec: json
+
 
           opensearch-tmux-io-context:
             type: elasticsearch

--- a/templates/rabbitmq/create_exchange.sh
+++ b/templates/rabbitmq/create_exchange.sh
@@ -1,0 +1,11 @@
+{%- set p = inventory.parameters %}
+#!/usr/bin/env bash
+
+RABBITMQ_ENDPOINT=`minikube ip`:{{ p.rabbitmq_manage_node_port }}
+
+{% if "rabbitmq_exchanges" in p %}
+{% for exhcnage_name, exchange in p.rabbitmq_exchanges.items() %}
+kubectl -n {{ p.rabbitmq_namespace }} exec {{ p.rabbitmq_release_name }}-0 -ti -- curl -i -u {{ p.rabbitmq_user }}:{{ p.rabbitmq_password }} -H "Content-type: application/json" -XPUT -d'{{ exchange | to_json }}' localhost:15672/api/exchanges/%2f/io-context
+{% endfor %} {# for exhcnage_name, exchange in rabbitmq_exchanges.items() #}
+{% endif %}
+


### PR DESCRIPTION
Add a RabbitMQ deployment in Kubernetes with a simple exchange configuration. 
Route the vector sink 'raw-io-context' to the 'io-context' RabbitMQ exchange